### PR TITLE
Feature userid sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,34 @@ Generated passwords comply with PAM360 **Strong** policy:
 - Contains uppercase and lowercase letters
 - Contains numbers
 
+## PAM360 Sharing Strategy
+
+A practical sharing strategy in PAM360 is to treat sharing as **authorization to use a credential**, not as a distribution mechanism, and to enforce **least privilege + group-based access + fast revocation**.
+
+### Recommended Approach
+
+**1. Prefer User Groups / Resource Groups over per-user sharing**
+
+Model access as: `Team (user group) → Environment/Scope (resource group)`
+
+Use the bulk share resource groups endpoints (API 9.9 / 9.10) as your default, and reserve per-resource/per-account sharing for exceptions. This aligns with PAM360's operational model where sharing is typically done at resource or resource-group level for many systems.
+
+**2. Use least privilege on accessType**
+
+| Access Type | Use Case |
+|-------------|----------|
+| `view` | Auditors/visibility use-cases (read-only) |
+| `modify` | Operators who must use the password and may need to update metadata, but shouldn't re-share widely |
+| `fullaccess` | Credential owners / PAM admins only - implies complete management and the ability to re-share |
+
+### This Toolkit's Default
+
+This toolkit uses:
+- **`fullaccess`** for resource-level sharing (API 9.1)
+- **`modify`** for account-level sharing (API 9.5)
+
+Adjust the `ACCESSTYPE` values in the playbook based on your organization's security requirements.
+
 ## Security Considerations
 
 - Store API tokens securely (use Ansible Vault for production)

--- a/ansible/roles/pam360_sync/tasks/main.yml
+++ b/ansible/roles/pam360_sync/tasks/main.yml
@@ -7,32 +7,38 @@
     user_status: {}
 
 # =======================================================
-# 1. Lookup PAM360 Share User ID from Username (API 4.5)
+# 1. Lookup PAM360 Share User IDs from Usernames (API 4.5)
 # =======================================================
-- name: Get PAM360 user ID from username (API 4.5)
+- name: Initialize share users list
+  set_fact:
+    pam_share_users: []
+
+- name: Get PAM360 user IDs from usernames (API 4.5)
   uri:
-    url: "{{ pam_url }}/restapi/json/v1/user/getUserId?USERNAME={{ pam_share_user_name }}"
+    url: "{{ pam_url }}/restapi/json/v1/user/getUserId?USERNAME={{ item }}"
     method: GET
     headers:
       AUTHTOKEN: "{{ pam_token }}"
     validate_certs: "{{ pam_validate_certs }}"
-  register: share_user_lookup
+  register: share_user_lookups
   delegate_to: localhost
   become: false
-  when: pam_share_user_name is defined
+  loop: "{{ pam_share_user_names | default([]) }}"
+  when: pam_share_user_names is defined
 
-- name: Set share user ID from lookup
+- name: Build share users list with IDs
   set_fact:
-    pam_share_user_id: "{{ share_user_lookup.json.operation.Details.USERID }}"
+    pam_share_users: "{{ pam_share_users + [{'name': item.item, 'id': item.json.operation.Details.USERID}] }}"
+  loop: "{{ share_user_lookups.results | default([]) }}"
   when:
-    - share_user_lookup is defined
-    - share_user_lookup.json is defined
-    - share_user_lookup.json.operation.result.status == 'Success'
+    - item.json is defined
+    - item.json.operation.result.status == 'Success'
+  no_log: true
 
-- name: Debug share user lookup
+- name: Debug share users lookup
   debug:
-    msg: "PAM360 share user '{{ pam_share_user_name }}' has ID: {{ pam_share_user_id }}"
-  when: pam_share_user_name is defined
+    msg: "PAM360 share users: {{ pam_share_users | map(attribute='name') | list }} -> IDs: {{ pam_share_users | map(attribute='id') | list }}"
+  when: pam_share_users | length > 0
 
 # =======================================================
 # 2. Generate Passwords for Target Users
@@ -192,9 +198,9 @@
   no_log: false
 
 # =======================================================
-# 5. Share Resource (API 9.1)
+# 5. Share Resource with Users (API 9.1)
 # =======================================================
-- name: Share Resource with User
+- name: Share Resource with Users
   uri:
     url: "{{ pam_url }}/restapi/json/v1/resources/{{ pam_resource_id }}/share"
     method: PUT
@@ -202,19 +208,25 @@
       AUTHTOKEN: "{{ pam_token }}"
       Content-Type: "text/json"
     validate_certs: "{{ pam_validate_certs }}"
-    body: 'INPUT_DATA={"operation":{"Details":{"ACCESSTYPE":"fullaccess","USERID":"{{ pam_share_user_id }}"}}}'
-  register: share_response
+    body: 'INPUT_DATA={"operation":{"Details":{"ACCESSTYPE":"fullaccess","USERID":"{{ item.id }}"}}}'
+  loop: "{{ pam_share_users }}"
+  register: share_responses
   delegate_to: localhost
   become: false
-  when: pam_resource_id is defined
+  when:
+    - pam_resource_id is defined
+    - pam_share_users | length > 0
 
-- name: Debug share result
+- name: Debug share results
   debug:
-    msg: "Share result: {{ share_response.json.operation.result.message | default('Skipped') }}"
-  when: share_response is defined
+    msg: "Shared resource with '{{ item.item.name }}': {{ item.json.operation.result.message | default('Skipped') }}"
+  loop: "{{ share_responses.results | default([]) }}"
+  when:
+    - share_responses is defined
+    - item.json is defined
 
 # =======================================================
-# 5b. Share Accounts with User (API 9.5)
+# 5b. Share Accounts with Users (API 9.5)
 # =======================================================
 - name: Get account IDs for sharing
   uri:
@@ -228,28 +240,37 @@
   become: false
   when: pam_resource_id is defined
 
-- name: Share each account with user (API 9.5)
+- name: Build account-user share combinations
+  set_fact:
+    account_user_shares: "{{ account_user_shares | default([]) + [{'account_id': item.0['ACCOUNT ID'], 'account_name': item.0['ACCOUNT NAME'], 'user_id': item.1.id, 'user_name': item.1.name}] }}"
+  loop: "{{ accounts_for_sharing.json.operation.Details['ACCOUNT LIST'] | default([]) | product(pam_share_users) | list }}"
+  when:
+    - accounts_for_sharing is defined
+    - accounts_for_sharing.json is defined
+    - pam_share_users | length > 0
+  no_log: true
+
+- name: Share each account with each user (API 9.5)
   uri:
-    url: "{{ pam_url }}/restapi/json/v1/resources/{{ pam_resource_id }}/accounts/{{ item['ACCOUNT ID'] }}/share"
+    url: "{{ pam_url }}/restapi/json/v1/resources/{{ pam_resource_id }}/accounts/{{ item.account_id }}/share"
     method: PUT
     headers:
       AUTHTOKEN: "{{ pam_token }}"
       Content-Type: "text/json"
     validate_certs: "{{ pam_validate_certs }}"
-    body: 'INPUT_DATA={"operation":{"Details":{"ACCESSTYPE":"modify","USERID":"{{ pam_share_user_id }}"}}}'
+    body: 'INPUT_DATA={"operation":{"Details":{"ACCESSTYPE":"modify","USERID":"{{ item.user_id }}"}}}'
     status_code: [200, 201, 400, 401, 403, 404, 500]
-  loop: "{{ accounts_for_sharing.json.operation.Details['ACCOUNT LIST'] | default([]) }}"
+  loop: "{{ account_user_shares | default([]) }}"
   register: share_accounts_response
   delegate_to: localhost
   become: false
   when:
     - pam_resource_id is defined
-    - accounts_for_sharing is defined
-    - accounts_for_sharing.json is defined
+    - account_user_shares is defined
 
 - name: Debug account share results
   debug:
-    msg: "Shared account '{{ item.item['ACCOUNT NAME'] }}': {{ item.json.operation.result.message | default('Unknown') }}"
+    msg: "Shared account '{{ item.item.account_name }}' with '{{ item.item.user_name }}': {{ item.json.operation.result.message | default('Unknown') }}"
   loop: "{{ share_accounts_response.results | default([]) }}"
   when:
     - share_accounts_response is defined

--- a/ansible/roles/pam360_sync/tasks/main.yml
+++ b/ansible/roles/pam360_sync/tasks/main.yml
@@ -7,7 +7,35 @@
     user_status: {}
 
 # =======================================================
-# 1. Generate Passwords for Target Users
+# 1. Lookup PAM360 Share User ID from Username (API 4.5)
+# =======================================================
+- name: Get PAM360 user ID from username (API 4.5)
+  uri:
+    url: "{{ pam_url }}/restapi/json/v1/user/getUserId?USERNAME={{ pam_share_user_name }}"
+    method: GET
+    headers:
+      AUTHTOKEN: "{{ pam_token }}"
+    validate_certs: "{{ pam_validate_certs }}"
+  register: share_user_lookup
+  delegate_to: localhost
+  become: false
+  when: pam_share_user_name is defined
+
+- name: Set share user ID from lookup
+  set_fact:
+    pam_share_user_id: "{{ share_user_lookup.json.operation.Details.USERID }}"
+  when:
+    - share_user_lookup is defined
+    - share_user_lookup.json is defined
+    - share_user_lookup.json.operation.result.status == 'Success'
+
+- name: Debug share user lookup
+  debug:
+    msg: "PAM360 share user '{{ pam_share_user_name }}' has ID: {{ pam_share_user_id }}"
+  when: pam_share_user_name is defined
+
+# =======================================================
+# 2. Generate Passwords for Target Users
 # =======================================================
 - name: Generate cleartext passwords for target users
   set_fact:
@@ -16,7 +44,7 @@
   no_log: true
 
 # =======================================================
-# 2. Check Resource Existence (API 1.1)
+# 3. Check Resource Existence (API 1.1)
 # =======================================================
 - name: Fetch all resources from PAM360 to check existence
   uri:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -14,7 +14,7 @@
       - admin
     pam_resource_group_name: "Linux Servers"
     pam_share_user_name: "admin"
-    pam_share_user_id: "1"
+    
 
   roles:
     - pam360_sync

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -14,7 +14,6 @@
       - admin
     pam_resource_group_name: "Linux Servers"
     pam_share_user_name: "admin"
-    
 
   roles:
     - pam360_sync

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -13,7 +13,9 @@
       - root
       - admin
     pam_resource_group_name: "Linux Servers"
-    pam_share_user_name: "admin"
+    pam_share_user_names: 
+      - "admin"
+      - "tsuliman"
 
   roles:
     - pam360_sync

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -13,6 +13,7 @@
       - root
       - admin
     pam_resource_group_name: "Linux Servers"
+    pam_share_user_name: "admin"
     pam_share_user_id: "1"
 
   roles:


### PR DESCRIPTION
Here’s a PR description you can paste that matches the commits and makes review easy.

**Suggested PR description (copy/paste):**

### Summary

This PR replaces hardcoded/static PAM360 share user IDs with **dynamic username → USERID lookup** and enables **sharing to multiple users** for both resource-level (API 9.1) and account-level (API 9.5) sharing.

### What changed

* Added `pam_share_user_names` to `ansible/site.yml` as the primary configuration input (replaces `pam_share_user_id`).
* Implemented username → USERID resolution via **API 4.5** (`/user/getUserId?USERNAME=...`) and builds an internal `pam_share_users` list.
* Updated sharing tasks to:

  * Share the **resource** with *each* resolved user (API 9.1).
  * Share **each account** with *each* resolved user using a cartesian product (API 9.5).
* Added README documentation describing recommended PAM360 sharing strategy and accessType guidance.

### Why

* Avoids brittle configurations where numeric USERIDs differ across PAM360 environments.
* Supports real-world ops workflows where multiple admins/operators require access without duplicating playbooks.
* Moves toward least-privilege and more maintainable sharing automation.

### Backward compatibility / behavior

* `pam_share_user_id` is no longer used by default; sharing runs only when `pam_share_user_names` is provided and at least one username resolves successfully.
* Current defaults remain:

  * Resource sharing uses `fullaccess`
  * Account sharing uses `modify`
    (can be tightened later via variables if desired)

### Testing

* Verified playbook execution with:

  * 2 share users (`admin`, `tsuliman`)
  * existing resource and accounts
  * sharing loops executed and returned success messages in debug output

### Notes / follow-ups

* Consider adding optional vars to control `ACCESSTYPE` (e.g., `pam_share_resource_access_type`, `pam_share_account_access_type`) and to support group-based sharing (API 9.3/9.4/9.9/9.10) for scale.

If you want a shorter version (1–2 paragraphs), tell me and I’ll compress it.
